### PR TITLE
Move admin edit of custom traits to new Admin tab, commas for roles

### DIFF
--- a/app/templates/char-edit.hbs
+++ b/app/templates/char-edit.hbs
@@ -6,13 +6,6 @@
         <li><a data-toggle="tab" href="#relationships">Relationships</a></li>
         <li><a data-toggle="tab" href="#hooks">RP Hooks</a></li>
         <li><a data-toggle="tab" href="#descs">Descriptions</a></li>
-        {{#if model.char.is_profile_manager}}
-        <li><a data-toggle="tab" href="#bg">Background</a></li>
-	      <li><a data-toggle="tab" href="#powers">Powers</a></li> 
-	      <li><a data-toggle="tab" href="#skills">Skills</a></li> 
-	      <li><a data-toggle="tab" href="#resources">Resources</a></li> 
-	      <li><a data-toggle="tab" href="#drawbacks">Drawbacks</a></li> 
-        {{/if}}
         <li><a data-toggle="tab" href="#files">Files</a></li>
         {{#if model.char.show_admin_tab}}
         <li><a data-toggle="tab" href="#admin">Admin</a></li>
@@ -29,24 +22,6 @@
       <CharEditRelationships @model={{model}} />
       <CharEditDescs @model={{model}} />
       
-      {{#if model.char.is_profile_manager}}
-      <div id="bg" class="tab-pane fade in">
-          <MarkdownEditor @text={{model.char.background}} />
-      </div>
-      <div id="powers" class="tab-pane fade">
-          <MarkdownEditor @text={{model.char.custom.powers}} />
-      </div>
-      <div id="skills" class="tab-pane fade">
-          <MarkdownEditor @text={{model.char.custom.skills}} />
-      </div>
-      <div id="resources" class="tab-pane fade">
-          <MarkdownEditor @text={{model.char.custom.resources}} />
-      </div>
-      <div id="drawbacks" class="tab-pane fade">
-          <MarkdownEditor @text={{model.char.custom.drawbacks}} />
-      </div>
-      {{/if}}
-
       <div id="hooks" class="tab-pane fade in">
           <MarkdownEditor @text={{model.char.rp_hooks}} />
         </div>

--- a/app/templates/components/char-edit-admin.hbs
+++ b/app/templates/components/char-edit-admin.hbs
@@ -4,6 +4,26 @@
     <h3>Background</h3>
     
     <MarkdownEditor @text={{model.char.background}} />
+
+  <hr>
+    <h3>Powers</h3>
+    
+    <MarkdownEditor @text={{model.char.custom.powers}} />
+
+  <hr>
+    <h3>Skills</h3>
+
+    <MarkdownEditor @text={{model.char.custom.skills}} />
+
+  <hr>
+    <h3>Resources</h3>
+
+    <MarkdownEditor @text={{model.char.custom.resources}} />
+
+  <hr>
+    <h3>Drawbacks</h3>
+
+    <MarkdownEditor @text={{model.char.custom.drawbacks}} />
   {{/if}}
   
 

--- a/app/templates/roles.hbs
+++ b/app/templates/roles.hbs
@@ -14,9 +14,9 @@
     {{#if role.chars}}
     <td>
       
-      {{#each role.chars as |char|}}
-      {{char}}
-      {{/each}}
+      {{#each role.chars as |char c| ~}}
+      {{#if c}}, {{/if}}{{char}}
+      {{~/each}}
     
     </td>
     {{/if}}


### PR DESCRIPTION
Addition of the Admin tab in the character profile edit necessitated redoing the custom powers/skills/resources/drawbacks tabs.
Edit boxes for these were all moved onto the Admin tab, where Edit Background was also moved.
Commas added between char names on the new Roles page.